### PR TITLE
templating

### DIFF
--- a/core-implementation/src/main/java/gg/solarmc/loader/impl/SimpleDataCenter.java
+++ b/core-implementation/src/main/java/gg/solarmc/loader/impl/SimpleDataCenter.java
@@ -22,6 +22,7 @@ package gg.solarmc.loader.impl;
 import gg.solarmc.loader.DataCenter;
 import gg.solarmc.loader.OnlineSolarPlayer;
 import gg.solarmc.loader.SolarPlayer;
+import gg.solarmc.loader.Transaction;
 import gg.solarmc.loader.data.DataKey;
 import gg.solarmc.loader.data.DataManager;
 import org.jooq.DSLContext;
@@ -60,6 +61,11 @@ public final class SimpleDataCenter implements DataCenter {
 		this.icarus = icarus;
 		this.playerTracker = playerTracker;
 		this.loginHandler = loginHandler;
+	}
+
+	@Override
+	public CentralisedFuture<Transaction> provideTransact() {
+		return icarus.transactionSource().transact(transact -> transact);
 	}
 
 	@Override

--- a/core/src/main/java/gg/solarmc/loader/DataCenter.java
+++ b/core/src/main/java/gg/solarmc/loader/DataCenter.java
@@ -28,6 +28,8 @@ import java.util.UUID;
 
 public interface DataCenter {
 
+	CentralisedFuture<Transaction> provideTransact();
+
 	/**
 	 * Runs a transaction which does not return a result. Helper method
 	 * for {@link #transact(TransactionActor)}
@@ -95,5 +97,5 @@ public interface DataCenter {
 	 * solar player.
 	 */
 	CentralisedFuture<Optional<SolarPlayer>> lookupPlayer(UUID uuid);
-
+	
 }


### PR DESCRIPTION
I'd like to add a feature like this 

`CentralisedFuture<Transaction> provideTransact();`

to the code. I'm fairly sure my current implementation is wrong or bad or something bad will be found about it, but the point here is not top notch code, but to show that a feature is required since i'm not sure if i can implement it myself

This feature would be useful in the context of methods that provide completablefutures and use the completablefuture's builder style methods as you can do something like

`future.thenApply(transaction -> { //do something safely with transaction }).thenCombine(// another future that starts with a thenApply)`

This would make writing api-using code a lot less tedious, although i do not know of the safety of this method since someone could probably block and cache the transaction in memory causing pain and suffering, so a safer implementation of this is probably in order